### PR TITLE
[S14P11B104-194] byte-오디오file 변환 함수 추가 및 스트리밍 응답 로직 수정

### DIFF
--- a/FastapiConnectGuide.md
+++ b/FastapiConnectGuide.md
@@ -1,0 +1,123 @@
+# AI 서버 설정 가이드  
+
+본 가이드는 **[바르미] AI Gateway와 연동되는 외부 AI 서버**를  
+개인 노트북 또는 로컬 PC 환경에서 실행하기 위한 설정 절차를 정리한다.
+
+AI 서버는 **모델 로딩 및 추론을 담당**하며,  
+서비스 백엔드나 AI Gateway와는 **HTTP API 통신으로만 연결**된다.
+
+
+## 1. 역할 정리
+
+외부 AI 서버의 책임은 다음과 같다.
+
+- WhisperX, CREPE 등 **AI 분석 모델 로딩**
+- 입력 데이터 기반 **추론 수행**
+- 분석 결과를 **JSON 형태로 반환**
+- FastAPI 기반 API 제공 (`/health`, `/output` 등)
+
+
+## 2. 프로젝트 기본 구조 예시
+```
+ai-server/
+├── ai_server.py # FastAPI 서버 엔트리포인트
+├── analysis/
+│ └── intonation.py # WhisperX / CREPE 분석 로직
+├── wav_data/
+│ └── sample.wav
+├── requirements.txt
+└── README.md
+```
+
+## 4. 가상환경 생성 및 활성화
+
+### conda 사용 시
+```bash
+conda create -n ai_env python=3.10 -y
+conda activate ai_env
+```
+### venv 사용시 
+```bash
+python -m venv ai_env
+source ai_env/bin/activate   # macOS/Linux
+ai_env\Scripts\activate      # Windows
+```
+## 5. 필수 패키지 설치
+### 기본 서버 패키지
+```bash
+pip install fastapi uvicorn httpx
+```
+## 6. FastAPI 서버 구현 예시
+### ai_server.py
+
+```python
+from fastapi import FastAPI, HTTPException
+import uvicorn
+
+from demo import run_intonation_analysis
+
+app = FastAPI()
+
+TEST_FILE = "./wav_data/i_am_a_student_test.wav"
+
+@app.get("/health")
+def health():
+    return {"ok": True}
+
+@app.post("/output")
+def output():
+    try:
+        data = run_intonation_analysis(TEST_FILE)
+        return {"file": TEST_FILE, "result": data}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+if __name__ == "__main__":
+    uvicorn.run("ai_server:app", host="0.0.0.0", port=8000, reload=False)
+```
+
+## 7. 서버 실행
+```bash
+python ai_server.py
+```
+- 정상 실행 시 로그:
+`Uvicorn running on http://0.0.0.0:8000`
+
+## 8. 로컬 테스트
+### Health 체크
+```
+curl http://localhost:8000/health
+```
+### Output 테스트
+```
+curl -X POST http://localhost:8000/output \
+  -H "Content-Type: application/json" \
+  -d '{"test":"data"}'
+```
+
+## 9. ngrok을 이용한 외부 노출
+### ngrok 설치
+   - https://ngrok.com/download
+
+### 인증 토큰 등록 (1회)
+```bash
+ngrok config add-authtoken <YOUR_TOKEN>
+```
+### 터널 실행
+```bash
+ngrok http 8000
+```
+
+출력 예:
+```Forwarding  https://xxxx-xxxx.ngrok-free.dev -> http://localhost:8000```
+
+## 10. AI Gateway와의 연동 규칙
+AI 서버는 반드시 다음 엔드포인트를 제공해야 한다.
+
+Method	| Path	   |  설명
+GET	    | /health  |  서버 상태 확인
+POST	| /output  |  AI 분석 결과 반환
+
+- 응답은 반드시 JSON
+- HTTP status는 성공 시 200 OK
+- 내부 에러는 FastAPI Exception으로 처리

--- a/main.py
+++ b/main.py
@@ -1,0 +1,64 @@
+from fastapi import FastAPI, UploadFile, File
+from fastapi.responses import StreamingResponse
+import shutil
+import os
+
+from src.services.audio_io import bytes_to_audio_file, safe_remove
+from src.services.speech_pipeline import analyze_speech_stream
+from src.models.stt_whisper import get_whisperx_models
+
+app = FastAPI(title="Speech Analysis API")
+
+# 전역 변수
+loaded_models = None
+
+@app.on_event("startup")
+async def startup_event():
+    global loaded_models
+    print("⏳ 모델 로딩 중...")
+    loaded_models = get_whisperx_models(
+        model_name="small.en",
+        vad_method="silero"
+    )
+    print("✅ 모델 로딩 완료!")
+
+@app.on_event("shutdown")
+async def shutdown_event():
+    global loaded_models
+    loaded_models = None
+    print("🛑 서버 종료")
+
+@app.post("/analyze")
+async def analyze(file: UploadFile = File(...)):
+    if not file.filename:
+        return {"error": "파일 이름이 없습니다"}
+    
+    # 1. 파일 읽기 (Bytes)
+    audio_bytes = await file.read()
+    
+    # 2. 임시 파일 생성
+    audio_path = bytes_to_audio_file(audio_bytes, suffix=".wav") 
+    
+    # 3. 제너레이터 래퍼
+    def stream_with_cleanup():
+        try:
+            # 분석 스트림 실행 (yield를 통해 하나씩 전달)
+            for chunk in analyze_speech_stream(
+                audio_path=audio_path,
+                loaded_models=loaded_models,
+                mode="all"
+            ):
+                yield chunk
+        finally:
+            print(f"🗑️ 임시 파일 삭제: {audio_path}")
+            safe_remove(audio_path)
+
+    # 4. StreamingResponse 반환
+    return StreamingResponse(
+        stream_with_cleanup(), 
+        media_type="application/x-ndjson"
+    )
+
+if __name__ == "__main__":
+    import uvicorn
+    uvicorn.run(app, host="0.0.0.0", port=8000)

--- a/src/models/stt_whisper.py
+++ b/src/models/stt_whisper.py
@@ -68,7 +68,12 @@ def get_whisperx_models(model_name: str = "small.en", vad_method: str = "silero"
     _MODEL_CACHE["metadata"] = metadata
     _MODEL_CACHE["device"] = device
 
-    return model, model_a, metadata, device
+    return WhisperModels(
+        model=model,
+        align_model=model_a,
+        metadata=metadata,
+        device=device
+    )
 
 # WhisperX 단어 타이밍 추출 함수
 def extract_word_timings(audio_path: str, model, model_a, metadata, device: str, batch_size: int = 16):

--- a/src/services/audio_io.py
+++ b/src/services/audio_io.py
@@ -1,0 +1,40 @@
+# src/services/audio_io.py
+
+from __future__ import annotations
+
+import os
+import tempfile
+
+def bytes_to_audio_file(
+    audio_bytes: bytes,
+    suffix: str = ".wav",
+) -> str:
+    """
+    [기능] 오디오 bytes를 임시 파일로 저장하고 그 파일 경로를 반환합니다.
+
+    [주의]
+    - 반환된 파일은 사용 후 반드시 삭제해야 합니다.
+    """
+    if not audio_bytes:
+        raise ValueError("audio_bytes is empty")
+
+    # 임시 파일 생성
+      # fd: OS 레벨 파일 디스크립터(핸들)
+      # path: 임시 파일 경로(문자열)
+    fd, path = tempfile.mkstemp(suffix=suffix)
+    # mkstemp는 OS-level fd를 주므로, open으로 다시 쓰고 fd 닫기
+    os.close(fd)
+
+    with open(path, "wb") as f:
+        f.write(audio_bytes)
+
+    return path
+
+
+def safe_remove(path: str) -> None:
+    """[기능] 파일이 존재하면 삭제"""
+    try:
+        if path and os.path.exists(path):
+            os.remove(path)
+    except Exception:
+        pass

--- a/src/services/audio_io.py
+++ b/src/services/audio_io.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import os
 import tempfile
+import contextlib
+from typing import Generator
 
 def bytes_to_audio_file(
     audio_bytes: bytes,
@@ -38,3 +40,15 @@ def safe_remove(path: str) -> None:
             os.remove(path)
     except Exception:
         pass
+
+@contextlib.contextmanager
+def temp_audio_file(file_bytes: bytes, suffix: str = ".wav") -> Generator[str, None, None]:
+    """
+    [기능] with 문과 함께 사용하여 임시 파일을 생성하고,
+          사용이 끝나면(블록 탈출 시) 자동으로 삭제합니다.
+    """
+    path = bytes_to_audio_file(file_bytes, suffix) # 파일 생성
+    try:
+        yield path # 파일 경로를 빌려줌
+    finally:
+        safe_remove(path) # 사용 후 삭제

--- a/src/services/speech_pipeline.py
+++ b/src/services/speech_pipeline.py
@@ -84,12 +84,6 @@ def analyze_speech_stream(
         return
 
     words = [w["word"] for w in word_segments]
-    
-    # 기본 결과 구조 생성
-    yield json.dumps({
-        "type": "words",
-        "data": words
-    }, ensure_ascii=False) + "\n"
 
     # 실행할 작업 플래그 설정
     do_pron = mode in ("pron", "all")

--- a/src/services/speech_pipeline.py
+++ b/src/services/speech_pipeline.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from typing import Any, Dict, List, Literal
-from concurrent.futures import ThreadPoolExecutor
-
+from typing import Any, Dict, List, Literal, Generator
+from concurrent.futures import ThreadPoolExecutor, as_completed
+import json
 from src.models.stt_whisper import (
     get_whisperx_models,
     extract_word_timings,
@@ -49,13 +49,13 @@ def _process_intonation(
     return merge_words_with_pitch_curve(word_segments, pitch_result)
 
 
-def analyze_speech(
+def analyze_speech_stream(
     audio_path: str,
+    # whisper_model_name: str = "small.en",
+    # whisper_vad_method: str = "silero",
+    loaded_models: tuple,   # 이미 로딩된 모델을 받음
     mode: Mode = "all",
-    parallel: bool = True,
-    whisper_model_name: str = "small.en",
-    whisper_vad_method: str = "silero",
-) -> Dict[str, Any]:
+) -> Generator[str, None, None]:
     """
     [기능] 음성 파이프라인 메인 함수
     1. WhisperX (공통)
@@ -64,63 +64,103 @@ def analyze_speech(
     """
     
     # 1. WhisperX 공통 단계: 모델 로드 -> 실행 -> 메모리 정리
-    model, model_a, metadata, device = get_whisperx_models(
-        model_name=whisper_model_name,
-        vad_method=whisper_vad_method,
-    )
+    # model, model_a, metadata, device = get_whisperx_models(
+    #     model_name=whisper_model_name,
+    #     vad_method=whisper_vad_method,
+    # )
+    model, model_a, metadata, device = loaded_models
     
-    word_segments = extract_word_timings(
-        audio_path=audio_path,
-        model=model,
-        model_a=model_a,
-        metadata=metadata,
-        device=device,
-        batch_size=16,
-    )
+    try:
+        word_segments = extract_word_timings(
+            audio_path=audio_path,
+            model=model,
+            model_a=model_a,
+            metadata=metadata,
+            device=device,
+            batch_size=16,
+        )
+    except Exception as e:
+        yield json.dumps({"type": "error", "message": str(e)}) + "\n"
+        return
 
     words = [w["word"] for w in word_segments]
     
     # 기본 결과 구조 생성
-    result = {
-        # "mode": mode,
-        "words": words,
-        # "word_segments": word_segments,
-    }
+    yield json.dumps({
+        "type": "words",
+        "data": words
+    }, ensure_ascii=False) + "\n"
 
     # 실행할 작업 플래그 설정
     do_pron = mode in ("pron", "all")
     do_into = mode in ("inton", "all")
 
     # 2. 분석 실행
-    if parallel and do_pron and do_into:
-        # 병렬 모드 (G2P는 CPU, CREPE는 GPU를 주로 쓰므로 효율적일 수 있음)
-        with ThreadPoolExecutor(max_workers=2) as executor:
-            future_pron = executor.submit(_process_pronunciation, words)
-            future_into = executor.submit(_process_intonation, audio_path, word_segments, device)
-            
-            result["pron"] = future_pron.result()
-            result["inton"] = future_into.result()
-    else:
-        # 순차 처리
+    with ThreadPoolExecutor(max_workers=2) as executor:
+        future_map = {}
+
         if do_pron:
-            result["pron"] = _process_pronunciation(words)
+            # 발음 분석 작업 제출
+            f_pron = executor.submit(_process_pronunciation, words)
+            future_map[f_pron] = "pron"
         
         if do_into:
-            result["inton"] = _process_intonation(audio_path, word_segments, device)
+            # 인토네이션 분석 작업 제출
+            f_into = executor.submit(_process_intonation, audio_path, word_segments, device)
+            future_map[f_into] = "inton"
 
-    return result
-
+        # 먼저 끝나는 작업부터 yield (as_completed)
+        for future in as_completed(future_map):
+            task_type = future_map[future]
+            try:
+                result_data = future.result()
+                
+                # 결과 전송 (type으로 구분)
+                yield json.dumps({
+                    "type": task_type,
+                    "data": result_data
+                }, ensure_ascii=False) + "\n"
+                
+            except Exception as e:
+                yield json.dumps({
+                    "type": "error",
+                    "task": task_type,
+                    "message": str(e)
+                }, ensure_ascii=False) + "\n"
 
 # 로컬 실행 테스트용
 if __name__ == "__main__":
     import json
     import os
+    # 모델 로더 함수 import 필요
+    from src.models.stt_whisper import get_whisperx_models
 
     # 테스트 파일 경로 확인
     test_file = "./experiments/wav_data/i_like_to_dance.wav"
     
     if os.path.exists(test_file):
-        out = analyze_speech(test_file, mode="all", parallel=False)
-        print(json.dumps(out, indent=2, ensure_ascii=False))
+        print("⏳ [Test] 모델 로딩 중... (처음엔 시간이 좀 걸립니다)")
+        
+        # 1. 테스트를 위해 여기서 모델을 직접 로드합니다. (Main.py의 lifespan 역할)
+        # 실제 서버에서는 이미 로드된 걸 쓰지만, 로컬 테스트에선 직접 준비해야 합니다.
+        loaded_models_tuple = get_whisperx_models(
+            model_name="small.en", 
+            vad_method="silero"
+        )
+        print("✅ [Test] 모델 로딩 완료!")
+
+        print("🎤 [Test] 분석 시작...")
+        
+        # 2. 로드된 모델을 인자로 넘겨줍니다.
+        generator = analyze_speech_stream(
+            audio_path=test_file, 
+            mode="all", 
+            loaded_models=loaded_models_tuple # <--- 핵심: 모델 전달
+        )
+        
+        # 3. 결과 스트리밍 출력
+        for chunk in generator:
+            print(chunk.strip())
+            
     else:
-        print(f"파일을 찾을 수 없습니다: {test_file}")
+        print(f"❌ 파일을 찾을 수 없습니다: {test_file}")

--- a/src/services/speech_pipeline.py
+++ b/src/services/speech_pipeline.py
@@ -7,7 +7,7 @@ from src.models.stt_whisper import (
     get_whisperx_models,
     extract_word_timings,
 )
-
+from src.models.stt_whisper import WhisperModels
 from src.models.pitch_crepe import extract_pitch_crepe
 from src.models.align_merge import merge_words_with_pitch_curve
 from src.models.g2p import text_to_phonemes
@@ -53,7 +53,7 @@ def analyze_speech_stream(
     audio_path: str,
     # whisper_model_name: str = "small.en",
     # whisper_vad_method: str = "silero",
-    loaded_models: tuple,   # 이미 로딩된 모델을 받음
+    loaded_models: WhisperModels,   # 이미 로딩된 모델을 받음
     mode: Mode = "all",
 ) -> Generator[str, None, None]:
     """
@@ -68,7 +68,10 @@ def analyze_speech_stream(
     #     model_name=whisper_model_name,
     #     vad_method=whisper_vad_method,
     # )
-    model, model_a, metadata, device = loaded_models
+    model = loaded_models.model
+    model_a = loaded_models.align_model
+    metadata = loaded_models.metadata
+    device = loaded_models.device
     
     try:
         word_segments = extract_word_timings(


### PR DESCRIPTION
## 📌 개요
<!-- PR의 목적을 간단히 설명해주세요. -->
ai-gateway에서 전달하는 오디오 bytes를 AI 서버에서 임시 오디오 파일로 복원해 기존 모델 코드를 그대로 실행할 수 있도록 입력 처리를 추가했습니다.
또한 발음(pron) / 인토네이션(inton) 분석 결과를 먼저 완료되는 순서대로 스트리밍 전송할 수 있도록 파이프라인을 확장했습니다.

## ✨ 주요 변경 사항
<!-- PR의 주요 변경 사항을 작성해주세요. -->
- [x] 오디오 bytes → 임시 파일로 저장하는 입력 어댑터 추가 (`audio_io.py`)
- [x] pron / inton 작업을 병렬 실행하고 as_completed로 먼저 끝나는 결과부터 전송
- [x] WhisperX 모델은 외부에서 로딩된 인스턴스를 주입받아 재사용 가능하도록 구성(서비스 운영 시 startup 캐싱 전략에 대응)

## 🔍 관련 이슈
<!-- Jira 발행 티겟을 입력해주세요. -->
- [S14P11B104-194](https://ssafy.atlassian.net/browse/S14P11B104-194?atlOrigin=eyJpIjoiN2Y4ZWYwNWQ3YjExNGFmYmFjNzc0N2VhZTkxYjc0ZGMiLCJwIjoiaiJ9)

## 🙏 To Reviewers
<!-- 코드 이해를 위해 참고할 수 있는 자료나 팀원에게 전달할 내용 입력해주세요. -->
- 스트리밍 응답 포맷이 {"type": "...", "data": ...}\n 형태로 전달됩니다.
- 임시 파일 생성 후 분석 완료 시 삭제 처리가 누락되지 않도록 라우터/호출부에서 finally 처리(또는 context manager) 적용 여부 확인 부탁드립니다.

## 🧪 테스트 방법
1. `python -m src.services.speech_pipeline`
2. `analyze_speech_stream()` 실행 시 words → pron/inton 순으로 chunk 출력되는지 확인

## 📸 스크린샷/동작 확인
<!-- UI 변경이나 실행 결과를 캡처해서 첨부해주세요. -->
<img width="928" height="452" alt="image" src="https://github.com/user-attachments/assets/17af543e-c590-4839-b259-7220b24968bf" />

## ✅ 체크리스트
- [x] 로컬에서 pron/inton 결과 정상 출력 확인
- [x] 스트리밍 순서가 작업 완료 순서대로 오는지 확인(as_completed)
- [x] 임시 파일 삭제가 모든 예외 케이스에서도 보장되는지 확인(라우터에서 finally)
- [x] 다중 요청(동시성) 환경에서 WhisperX/CREPE 호출 안정성 확인